### PR TITLE
Add default emoji as downcased language

### DIFF
--- a/app/services/slack_bot.rb
+++ b/app/services/slack_bot.rb
@@ -88,6 +88,6 @@ class SlackBot
     elsif repo_name.include? 'angular'
       language = 'Angular'
     end
-    EMOJI_HASH.fetch language, "[#{language}]"
+    EMOJI_HASH.fetch language, ":#{language.downcase}:"
   end
 end

--- a/spec/services/slack_bot_spec.rb
+++ b/spec/services/slack_bot_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'SlackBot' do
+  let(:subject) { SlackBot.new({ channel: 'demo_channel' }) }
+  describe '#language_emoji' do
+    context 'when the repo includes React' do
+      it 'returns the correct emoji' do
+        expect(subject.language_emoji('javascript', 'this-is-react-repo')).to eq ':react:'
+      end
+    end
+    context 'when there is no emoji in the hash' do
+      it 'returns the default emoji (downcase language)' do
+        expect(subject.language_emoji('Exotic', 'repo_name')).to eq ':exotic:'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of showing `[language]` now it will show `:language:` so if there is an emoji with that name it will display it.