### PR TITLE
Fix chat_PostMessages param

### DIFF
--- a/app/services/slack_bot.rb
+++ b/app/services/slack_bot.rb
@@ -25,7 +25,7 @@ class SlackBot
   end
 
   def notify(message, username, avatar_url)
-    client.chat_postMessage(channel: @channel, text: message, as_user: false,
+    client.chat_postMessage(channel: @channel, text: message,
                             username: username, icon_url: avatar_url)
   end
 
@@ -70,7 +70,7 @@ class SlackBot
   end
 
   def extract_slack_body(body)
-    body = body.gsub("\r\n", ' ').split('\slack ')[1] || ''
+    body = body&.gsub("\r\n", ' ')&.split('\slack ')&[1] || ''
     format_body body
   end
 
@@ -88,6 +88,6 @@ class SlackBot
     elsif repo_name.include? 'angular'
       language = 'Angular'
     end
-    EMOJI_HASH.fetch language, ":#{language.downcase}:"
+    EMOJI_HASH.fetch language, ":#{language&.downcase}:"
   end
 end

--- a/spec/requests/api/v1/github_webhook/filter_spec.rb
+++ b/spec/requests/api/v1/github_webhook/filter_spec.rb
@@ -183,7 +183,7 @@ end
 
 def expect_notification(text: message)
   expect_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage)
-    .with(channel: channel, text: text, as_user: false, username: 'user', icon_url: 'image.png')
+    .with(channel: channel, text: text, username: 'user', icon_url: 'image.png')
 
   post api_v1_notifications_filter_path, params: params, as: :json
 end


### PR DESCRIPTION
### Summary

* Fix an error in the chat_PostMessage method, changing the way we call it. Probably, caused by the update of version when we call the service with the param `as_user: false` it returns invalid arguments. This value is set false as default, so i remove it and works fine.
* Fix when the body of a PR is nil and we try to parse it.
* Fix when the language is nil, because when i tried to test this project with an empty github project, there is not language so it broke. 

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.
Thanks for contributing to this project! -->
