### PR TITLE
Feature / Add feature to send prs to devops channel

### DIFF
--- a/app/services/slack_notification_service.rb
+++ b/app/services/slack_notification_service.rb
@@ -57,7 +57,7 @@ class SlackNotificationService
   def channel(params)
     lang = LANGUAGES[params.dig(:repository, :language)&.to_sym]
     repository_info = params.dig(:repository)
-    channel = "##{build_channel(lang, repository_info)}" if lang
+    channel = "##{build_channel(lang, repository_info)}"
 
     if search_channel(channel)
       channel
@@ -74,9 +74,23 @@ class SlackNotificationService
   end
 
   def build_channel(lang, repository_info)
+    return 'devops-code-review' if devops_pr?(repository_info)
+
+    return build_lang_channel(lang, repository_info) if lang
+  end
+
+  def build_lang_channel(lang, repository_info)
     return js_channels(repository_info, lang) if %w[javascript typescript].include?(lang)
 
     "#{lang}-code-review"
+  end
+
+  def devops_pr?(repository_info)
+    return false unless repository_info
+
+    repo_name = repository_info[:name]
+
+    (repo_name&.include? 'devops') || (repo_name&.include? 'infra')
   end
 
   def filter_opened_action

--- a/spec/requests/api/v1/github_webhook/filter_spec.rb
+++ b/spec/requests/api/v1/github_webhook/filter_spec.rb
@@ -46,6 +46,21 @@ describe 'GET api/v1/notifications_filter', type: :request do
       end
     end
 
+    context 'when repository is a devops repository' do
+      let(:channel) { '#devops-code-review' }
+      before { mock_channel_response(channel) }
+
+      it 'sends message to correct channel' do
+        params[:repository][:name] = 'repository-devops-project '
+        expect_notification(text: "#{pull_request_link} <@user> Tiny PR :javascript:")
+      end
+
+      it 'sends message to correct channel' do
+        params[:repository][:name] = 'repository-infrastructure '
+        expect_notification(text: "#{pull_request_link} <@user> Tiny PR :javascript:")
+      end
+    end
+
     context 'repository name includes a technology' do
       before { mock_channel_response(channel) }
 


### PR DESCRIPTION
When a the repository's name of a opened PR has either the word "DevOps" or "infra", the app recognizes it as a DevOps repository and sends the PR to the default DevOps channel
