### PR TITLE
Slackbot initialization enhancement

### DIFF
--- a/app/services/slack_bot.rb
+++ b/app/services/slack_bot.rb
@@ -20,9 +20,11 @@ class SlackBot
 
   attr_reader :client, :channel
 
-  def initialize(params)
+  def initialize(channel:)
+    raise ArgumentError.new('Invalid channel') unless channel.present?
+
     @client = Slack::Web::Client.new
-    @channel = params[:channel]
+    @channel = channel
   end
 
   def notify(message, username, avatar_url)

--- a/spec/services/slack_bot_spec.rb
+++ b/spec/services/slack_bot_spec.rb
@@ -1,13 +1,22 @@
 require 'rails_helper'
 
 describe 'SlackBot' do
-  let(:subject) { SlackBot.new({ channel: 'demo_channel' }) }
+  let(:subject) { SlackBot.new(channel: 'demo_channel') }
+
+  describe 'initialization' do
+    it 'raise an error if channel is not present' do
+      expect { SlackBot.new(channel: nil) }.to raise_error(ArgumentError, 'Invalid channel')
+      expect { SlackBot.new(channel: '') }.to raise_error(ArgumentError, 'Invalid channel')
+    end
+  end
+
   describe '#language_emoji' do
     context 'when the repo includes React' do
       it 'returns the correct emoji' do
         expect(subject.language_emoji('javascript', 'this-is-react-repo')).to eq ':react:'
       end
     end
+
     context 'when there is no emoji in the hash' do
       it 'returns the default emoji (downcase language)' do
         expect(subject.language_emoji('Exotic', 'repo_name')).to eq ':exotic:'


### PR DESCRIPTION
### Summary

Changing initialization to not use a Hash to pass only a channel String param

### Other Information

The service that use this SlackBot class (`SlackNotificationService`) don't need changes because it uses it as

```ruby
    @slack_bot = SlackBot.new(channel: channel(params))
```