### PR TITLE
Remove client from public attributes

### DIFF
--- a/app/services/slack_bot.rb
+++ b/app/services/slack_bot.rb
@@ -18,7 +18,7 @@ class SlackBot
                   'R' => ':r-lang:',
                   'PHP' => ':php:' }.freeze
 
-  attr_reader :client, :channel
+  attr_reader :channel
 
   def initialize(params)
     @client = Slack::Web::Client.new
@@ -26,7 +26,7 @@ class SlackBot
   end
 
   def notify(message, username, avatar_url)
-    client.chat_postMessage(channel: @channel, text: message,
+    @client.chat_postMessage(channel: @channel, text: message,
                             username: username, icon_url: avatar_url)
   end
 
@@ -42,7 +42,7 @@ class SlackBot
   end
 
   def add_emoji(emoji, timestamp)
-    client.reactions_add(name: emoji,
+    @client.reactions_add(name: emoji,
                          channel: @channel,
                          timestamp: timestamp,
                          as_user: false)
@@ -58,7 +58,7 @@ class SlackBot
     matches.each do |match|
       timestamp = match[:ts]
       begin
-        client.chat_delete(channel: @channel, ts: timestamp) if timestamp
+        @client.chat_delete(channel: @channel, ts: timestamp) if timestamp
       rescue StandardError => e
         puts "An error of type #{e.class} happened, message is #{e.message}."
       end


### PR DESCRIPTION
### Summary

The client instance var. is an implementation detail of the bot, and makes no sense to be available outside the class that acts as a wrapper of the Slack gem.

### Other Information

None