### PR TITLE
Fix in controller to remove warning in logs

### DIFF
--- a/app/controllers/api/v1/github_webhook_controller.rb
+++ b/app/controllers/api/v1/github_webhook_controller.rb
@@ -8,6 +8,7 @@ module Api
       def filter
         slack_notification_service = SlackNotificationService.new(params)
         slack_notification_service.send_notification
+        head :no_content
       end
     end
   end


### PR DESCRIPTION
### Summary

Run specs w/master and this branch and validate that this message is removed: 
```
No template found for Api::V1::GithubWebhookController#filter, rendering head :no_content
```

### Other Information

None
